### PR TITLE
[WIP] adding function that attempts to do some sort of clustering

### DIFF
--- a/covid_moonshot/analysis/structures.py
+++ b/covid_moonshot/analysis/structures.py
@@ -138,6 +138,11 @@ def _get_representative_snapshot(traj, cluster_dist=0.5):
     drmsd : float
         standard devation of rmsd in Angstrom
     '''
+    
+    from simtk import unit
+    from scipy.cluster.hierarchy import ward, fcluster
+    from scipy.spatial.distance import pdist
+    
     distances = np.empty((traj.n_frames, traj.n_frames))
     for i in range(traj.n_frames):
         distances[i] = md.rmsd(traj, traj, i)
@@ -194,9 +199,6 @@ def cluster_snaphots(
     """
     import random
     import numpy as np
-    from simtk import unit
-    from scipy.cluster.hierarchy import ward, fcluster
-    from scipy.spatial.distance import pdist
 
     # open n random snaphots for the RUN
     for i in range(0, n_snapshots):


### PR DESCRIPTION
This PR adds the function `cluster_snapshots`

which loads up _N_ snapshots, does clustering based on the OLD LIGAND position, and then finds the index of the snapshot that is closest to the mean of the largest cluster.

This still needs work:

- [ ] pick frames based at random based on what is on disk (currently hard-coded which isn't safe if it tries to open a clone/gen that hasn't run, or if the number of clones/gens changes in future iterations
- [ ] is only running on the old-ligand, when in future may want to do for the new ligand too
- [ ] optimising clustering parameters. I chose 0.5 as it looked ok for one example, something else might be better
- [ ] add the ligand RMSD* and protein RMSD to the oemol/have it as an entry in the `ligands.sdf` file that is printed out
- [ ] integrating into the main analysis pipeline --- for now, lets use this as well as `extract_snapshot`, saving to disk with a different filename before we replace it

\* this is the ligand RMSD to itself, between the random snapshots, and _not_ the RMSD of the scaffold-core to the crystallographic positions (which would also be interesting)

