### PR TITLE
add filtered transformations tab

### DIFF
--- a/fah_xchem/analysis/__init__.py
+++ b/fah_xchem/analysis/__init__.py
@@ -85,25 +85,15 @@ def analyze_transformation(
 
     # Check for consistency across GENS, if requested
     if filter_gen_consistency:
-        if gens_are_consistent(complex_phase=complex_phase, solvent_phase=solvent_phase):
+        consistent_bool = gens_are_consistent(complex_phase=complex_phase, solvent_phase=solvent_phase, nsigma=1)
 
-            return TransformationAnalysis(
-                transformation=transformation,
-                reliable_transformation=True,
-                binding_free_energy=binding_free_energy, 
-                complex_phase=complex_phase,
-                solvent_phase=solvent_phase,
-            )
-
-        else:
-
-            return TransformationAnalysis(
-                transformation=transformation,
-                reliable_transformation=False,
-                binding_free_energy=binding_free_energy, 
-                complex_phase=complex_phase,
-                solvent_phase=solvent_phase,
-            )
+        return TransformationAnalysis(
+            transformation=transformation,
+            reliable_transformation=consistent_bool,
+            binding_free_energy=binding_free_energy, 
+            complex_phase=complex_phase,
+            solvent_phase=solvent_phase,
+        )
 
     else:
 

--- a/fah_xchem/analysis/__init__.py
+++ b/fah_xchem/analysis/__init__.py
@@ -24,7 +24,7 @@ from .exceptions import AnalysisError, DataValidationError
 from .extract_work import extract_work_pair
 from .free_energy import compute_relative_free_energy
 from .plots import generate_plots
-from .report import generate_report
+from .report import generate_report, gens_are_consistent
 from .structures import generate_representative_snapshots
 from .website import generate_website
 
@@ -82,8 +82,6 @@ def analyze_transformation(
     complex_phase = analyze_phase_partial(project=projects.complex_phase)
     solvent_phase = analyze_phase_partial(project=projects.solvent_phase)
     binding_free_energy = complex_phase.free_energy.delta_f - solvent_phase.free_energy.delta_f
-
-    from .report import gens_are_consistent
 
     # Check for consistency across GENS, if requested
     if filter_gen_consistency:

--- a/fah_xchem/analysis/__init__.py
+++ b/fah_xchem/analysis/__init__.py
@@ -81,16 +81,20 @@ def analyze_transformation(
 
     complex_phase = analyze_phase_partial(project=projects.complex_phase)
     solvent_phase = analyze_phase_partial(project=projects.solvent_phase)
-    binding_free_energy = complex_phase.free_energy.delta_f - solvent_phase.free_energy.delta_f
+    binding_free_energy = (
+        complex_phase.free_energy.delta_f - solvent_phase.free_energy.delta_f
+    )
 
     # Check for consistency across GENS, if requested
     if filter_gen_consistency:
-        consistent_bool = gens_are_consistent(complex_phase=complex_phase, solvent_phase=solvent_phase, nsigma=1)
+        consistent_bool = gens_are_consistent(
+            complex_phase=complex_phase, solvent_phase=solvent_phase, nsigma=1
+        )
 
         return TransformationAnalysis(
             transformation=transformation,
             reliable_transformation=consistent_bool,
-            binding_free_energy=binding_free_energy, 
+            binding_free_energy=binding_free_energy,
             complex_phase=complex_phase,
             solvent_phase=solvent_phase,
         )
@@ -102,7 +106,7 @@ def analyze_transformation(
             binding_free_energy=binding_free_energy,
             complex_phase=complex_phase,
             solvent_phase=solvent_phase,
-            )
+        )
 
 
 def analyze_transformation_or_warn(
@@ -145,9 +149,11 @@ def analyze_compound_series(
         ]
 
     # Sort transformations by RUN
-    #transformations.sort(key=lambda transformation_analysis : transformation_analysis.transformation.run_id)
+    # transformations.sort(key=lambda transformation_analysis : transformation_analysis.transformation.run_id)
     # Sort transformations by free energy difference
-    transformations.sort(key=lambda transformation_analysis : transformation_analysis.binding_free_energy.point)
+    transformations.sort(
+        key=lambda transformation_analysis: transformation_analysis.binding_free_energy.point
+    )
 
     # Warn about failures
     num_failed = len(series.transformations) - len(transformations)

--- a/fah_xchem/analysis/report.py
+++ b/fah_xchem/analysis/report.py
@@ -231,10 +231,10 @@ def generate_report(
 
         # Filter by consistency of GENs if requested
         if filter_gen_consistency:
-            reliable_transform = gens_are_consistent(transformation)
-            transformation.transformation.reliable_transform = reliable_transform
-            if not reliable_transform:
+            if not gens_are_consistent(transformation):
                 continue        
+            # Label current iteration as reliable (JSON boolean)
+            transformation.transformation.reliable_transform = "true"
 
         run = f"RUN{transformation.transformation.run_id}"
         path = os.path.join(results_path, "transformations", run)

--- a/fah_xchem/analysis/report.py
+++ b/fah_xchem/analysis/report.py
@@ -302,7 +302,7 @@ def generate_report(
             if transformation.reliable_transformation:
                 mols["reliable"]["oemols"].append(oemol)
 
-    logging.info(f"{len(oemols) + len(reliable_oemols)} molecules read")
+    logging.info(f"{len(mols["unreliable"]["oemols"])} molecules read")
 
     # Sort ligands in order of most favorable transformations
     import numpy as np
@@ -337,7 +337,7 @@ def generate_report(
     reliable_oemols = [mols["reliable"]["oemols"][index] for index in sorted_indices_reliable]
     reliable_refmols = [mols["reliable"]["refmols"][index] for index in sorted_indices_reliable]
 
-    logging.info(f"{len(oemols) + len(reliable_oemols)} molecules remain after filtering based on {max_binding_free_energy} threshold")
+    logging.info(f"{len(oemols)} molecules remain after filtering based on {max_binding_free_energy} threshold")
 
     # Write sorted molecules
     for filename in ["transformations-final-ligands.sdf", "transformations-final-ligands.csv", "transformations-final-ligands.mol2"]:

--- a/fah_xchem/analysis/report.py
+++ b/fah_xchem/analysis/report.py
@@ -302,7 +302,8 @@ def generate_report(
             if transformation.reliable_transformation:
                 mols["reliable"]["oemols"].append(oemol)
 
-    logging.info(f"{len(mols["unreliable"]["oemols"])} molecules read")
+
+    logging.info(f"{len(mols['unreliable']['oemols'])} molecules read")
 
     # Sort ligands in order of most favorable transformations
     import numpy as np

--- a/fah_xchem/analysis/report.py
+++ b/fah_xchem/analysis/report.py
@@ -234,9 +234,10 @@ def generate_report(
         if transformation.binding_free_energy.point >= max_binding_free_energy:
             continue
 
+        # TODO adapt the GEN consistency to write out to a different CSV etc files
         # Filter by consistency of GENs if requested
         if filter_gen_consistency:
-            if not gens_are_consistent(transformation):
+            if not transformation.reliable_transformation:
                 continue        
 
         run = f"RUN{transformation.transformation.run_id}"

--- a/fah_xchem/analysis/report.py
+++ b/fah_xchem/analysis/report.py
@@ -140,7 +140,7 @@ def gens_are_consistent(
     
     The last `ngens` generations will be checked for consistency with the overall estimate,
     and those with estimates that deviate by more than `nsigma` standard errors will be dropped.
-
+sprint-5-minimal-test.json
     Parameters
     ----------
     transformation : TransformationAnalysis
@@ -231,9 +231,11 @@ def generate_report(
 
         # Filter by consistency of GENs if requested
         if filter_gen_consistency:
-            if not gens_are_consistent(transformation):
+            reliable_transform = gens_are_consistent(transformation)
+            transformation.transformation.reliable_transform = reliable_transform
+            if not reliable_transform:
                 continue        
-        
+
         run = f"RUN{transformation.transformation.run_id}"
         path = os.path.join(results_path, "transformations", run)
 

--- a/fah_xchem/analysis/report.py
+++ b/fah_xchem/analysis/report.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 from ..schema import CompoundMicrostate, CompoundSeriesAnalysis, TransformationAnalysis
 from .constants import KT_KCALMOL
 
+
 def write_pdf_report(mollist, pdf_filename, iname):
     """
     Write molecules with SD Data to PDF
@@ -132,30 +133,30 @@ def RenderData(image, mol, tags):
 
 
 def gens_are_consistent(
-        complex_phase,
-        solvent_phase,
-        ngens: Optional[int] = 2,
-        nsigma: Optional[float] = 3,
+    complex_phase,
+    solvent_phase,
+    ngens: Optional[int] = 2,
+    nsigma: Optional[float] = 3,
 ) -> bool:
     """
-    Return True if GENs are consistent.
-    
-    The last `ngens` generations will be checked for consistency with the overall estimate,
-    and those with estimates that deviate by more than `nsigma` standard errors will be dropped.
-sprint-5-minimal-test.json
-    Parameters
-    ----------
-    complex_phase : ProjectPair
-        The complex phase ProjectPair object to use to check for consistency
-    solvent_phase : ProjectPair
-        The solvent phase ProjectPair object to use to check for consistency
-    ngens : int, optional, default=2
-        The last `ngens` generations will be checked for consistency with the overall estimate
-    nsigma : int, optional, default=3
-        Number of standard errors of overall estimate to use for consistency check
+        Return True if GENs are consistent.
+
+        The last `ngens` generations will be checked for consistency with the overall estimate,
+        and those with estimates that deviate by more than `nsigma` standard errors will be dropped.
+    sprint-5-minimal-test.json
+        Parameters
+        ----------
+        complex_phase : ProjectPair
+            The complex phase ProjectPair object to use to check for consistency
+        solvent_phase : ProjectPair
+            The solvent phase ProjectPair object to use to check for consistency
+        ngens : int, optional, default=2
+            The last `ngens` generations will be checked for consistency with the overall estimate
+        nsigma : int, optional, default=3
+            Number of standard errors of overall estimate to use for consistency check
     """
     # Collect free energy estimates for each GEN
-    ngens = min( len(complex_phase.gens), len(solvent_phase.gens) )
+    ngens = min(len(complex_phase.gens), len(solvent_phase.gens))
     gen_estimates = list()
     for gen in range(ngens):
         complex_delta_f = complex_phase.gens[gen].free_energy.delta_f
@@ -164,29 +165,31 @@ sprint-5-minimal-test.json
             continue
         binding_delta_f = complex_delta_f - solvent_delta_f
         gen_estimates.append(binding_delta_f)
-        
+
     if len(gen_estimates) < ngens:
         # We don't have enough GENs
         return False
 
     # Flag inconsistent if any GEN estimate is more than nsigma stderrs away from overall estimate
     for gen_delta_f in gen_estimates[-ngens:]:
-        overall_delta_f = complex_phase.free_energy.delta_f - solvent_phase.free_energy.delta_f
+        overall_delta_f = (
+            complex_phase.free_energy.delta_f - solvent_phase.free_energy.delta_f
+        )
         delta_f = overall_delta_f - gen_delta_f
-        #print(gen_delta_f, overall_delta_f, delta_f)
-        #if abs(delta_f.point) > nsigma*delta_f.stderr:
-        if abs(delta_f.point) > nsigma*gen_delta_f.stderr:
+        # print(gen_delta_f, overall_delta_f, delta_f)
+        # if abs(delta_f.point) > nsigma*delta_f.stderr:
+        if abs(delta_f.point) > nsigma * gen_delta_f.stderr:
             return False
-        
+
     return True
 
 
 def generate_report(
-        series: CompoundSeriesAnalysis,
-        results_path: str,
-        max_binding_free_energy: float=0.0,
-        consolidate_protein_snapshots: Optional[bool] = True,
-        filter_gen_consistency: Optional[bool] = True,
+    series: CompoundSeriesAnalysis,
+    results_path: str,
+    max_binding_free_energy: float = 0.0,
+    consolidate_protein_snapshots: Optional[bool] = True,
+    filter_gen_consistency: Optional[bool] = True,
 ) -> None:
     """
     Postprocess results of calculations to extract summary for compound prioritization
@@ -225,15 +228,9 @@ def generate_report(
     # TODO: Take this cutoff from global configuration
     # dictionary for target and reference molecules, with reliable and unreliable transformations
     mols = {
-        "reliable": {
-            "oemols": [],
-            "refmols": []
-            },
-        "unreliable":{
-            "oemols": [],
-            "refmols": []
-            }
-        }
+        "reliable": {"oemols": [], "refmols": []},
+        "unreliable": {"oemols": [], "refmols": []},
+    }
 
     # TODO : Iterate over compounds instead of transformations
     # Store optimal microstates for each compound, and representative snapshot paths for each microstate and compound in analysis
@@ -302,7 +299,6 @@ def generate_report(
             if transformation.reliable_transformation:
                 mols["reliable"]["oemols"].append(oemol)
 
-
     logging.info(f"{len(mols['unreliable']['oemols'])} molecules read")
 
     # Sort ligands in order of most favorable transformations
@@ -310,81 +306,132 @@ def generate_report(
 
     logging.info(f"Sorting molecules to prioritize most favorable transformations")
     sorted_indices = np.argsort(
-        [float(oechem.OEGetSDData(oemol, "DDG (kcal/mol)")) for oemol in mols["unreliable"]["oemols"]]
+        [
+            float(oechem.OEGetSDData(oemol, "DDG (kcal/mol)"))
+            for oemol in mols["unreliable"]["oemols"]
+        ]
     )
 
     if filter_gen_consistency:
         sorted_indices_reliable = np.argsort(
-            [float(oechem.OEGetSDData(oemol, "DDG (kcal/mol)")) for oemol in mols["reliable"]["oemols"]]
+            [
+                float(oechem.OEGetSDData(oemol, "DDG (kcal/mol)"))
+                for oemol in mols["reliable"]["oemols"]
+            ]
         )
 
     # Filter based on threshold
     sorted_indices = [
         index
         for index in sorted_indices
-        if (float(oechem.OEGetSDData(mols["unreliable"]["oemols"][index], "DDG (kcal/mol)")) < max_binding_free_energy)
+        if (
+            float(oechem.OEGetSDData(
+                    mols["unreliable"]["oemols"][index], "DDG (kcal/mol)"
+                )
+            )
+            < max_binding_free_energy
+        )
     ]
 
     if filter_gen_consistency:
         sorted_indices_reliable = [
             index
             for index in sorted_indices_reliable
-            if (float(oechem.OEGetSDData(mols["reliable"]["oemols"][index], "DDG (kcal/mol)")) < max_binding_free_energy)
+            if (
+                float(
+                    oechem.OEGetSDData(
+                        mols["reliable"]["oemols"][index], "DDG (kcal/mol)"
+                    )
+                )
+                < max_binding_free_energy
+            )
         ]
 
     # Slice
     oemols = [mols["unreliable"]["oemols"][index] for index in sorted_indices]
     refmols = [mols["unreliable"]["refmols"][index] for index in sorted_indices]
-    reliable_oemols = [mols["reliable"]["oemols"][index] for index in sorted_indices_reliable]
-    reliable_refmols = [mols["reliable"]["refmols"][index] for index in sorted_indices_reliable]
+    reliable_oemols = [
+        mols["reliable"]["oemols"][index] for index in sorted_indices_reliable
+    ]
+    reliable_refmols = [
+        mols["reliable"]["refmols"][index] for index in sorted_indices_reliable
+    ]
 
-    logging.info(f"{len(oemols)} molecules remain after filtering based on {max_binding_free_energy} threshold")
+    logging.info(
+        f"{len(oemols)} molecules remain after filtering based on {max_binding_free_energy} threshold"
+    )
 
     # Write sorted molecules
-    for filename in ["transformations-final-ligands.sdf", "transformations-final-ligands.csv", "transformations-final-ligands.mol2"]:
+    for filename in [
+        "transformations-final-ligands.sdf",
+        "transformations-final-ligands.csv",
+        "transformations-final-ligands.mol2",
+    ]:
         with oechem.oemolostream(os.path.join(results_path, filename)) as ofs:
             for oemol in track(oemols, description=f"Writing {filename}"):
                 oechem.OEWriteMolecule(ofs, oemol)
-    
+
     if filter_gen_consistency:
-        for filename in ["reliable-transformations-final-ligands.sdf", "reliable-transformations-final-ligands.csv", "reliable-transformations-final-ligands.mol2"]:
+        for filename in [
+            "reliable-transformations-final-ligands.sdf",
+            "reliable-transformations-final-ligands.csv",
+            "reliable-transformations-final-ligands.mol2",
+        ]:
             with oechem.oemolostream(os.path.join(results_path, filename)) as ofs:
                 for oemol in track(reliable_oemols, description=f"Writing {filename}"):
                     oechem.OEWriteMolecule(ofs, oemol)
 
     # Write PDF report
     write_pdf_report(
-        oemols, os.path.join(results_path, "transformations-final-ligands.pdf"), series.metadata.name
+        oemols,
+        os.path.join(results_path, "transformations-final-ligands.pdf"),
+        series.metadata.name,
     )
 
     if filter_gen_consistency:
         write_pdf_report(
-            reliable_oemols, os.path.join(results_path, "reliable-transformations-final-ligands.pdf"), series.metadata.name
+            reliable_oemols,
+            os.path.join(results_path, "reliable-transformations-final-ligands.pdf"),
+            series.metadata.name,
         )
 
     # Write reference molecules
-    for filename in ["transformations-initial-ligands.sdf", "transformations-initial-ligands.mol2"]:
+    for filename in [
+        "transformations-initial-ligands.sdf",
+        "transformations-initial-ligands.mol2",
+    ]:
         with oechem.oemolostream(os.path.join(results_path, filename)) as ofs:
             for refmol in track(refmols, description=f"Writing {filename}"):
                 oechem.OEWriteMolecule(ofs, refmol)
 
     if filter_gen_consistency:
-        for filename in ["reliable-transformations-initial-ligands.sdf", "reliable-transformations-initial-ligands.mol2"]:
+        for filename in [
+            "reliable-transformations-initial-ligands.sdf",
+            "reliable-transformations-initial-ligands.mol2",
+        ]:
             with oechem.oemolostream(os.path.join(results_path, filename)) as ofs:
-                for refmol in track(reliable_refmols, description=f"Writing {filename}"):
+                for refmol in track(
+                    reliable_refmols, description=f"Writing {filename}"
+                ):
                     oechem.OEWriteMolecule(ofs, refmol)
 
-    #TODO fix snapshots to write out reliable transforms too
     if consolidate_protein_snapshots:
         consolidate_protein_snapshots_into_pdb(oemols, results_path)
         if filter_gen_consistency:
-            consolidate_protein_snapshots_into_pdb(reliable_oemols, results_path, pdb_filename="reliable-transformations-final-proteins.pdb")
+            consolidate_protein_snapshots_into_pdb(
+                reliable_oemols,
+                results_path,
+                pdb_filename="reliable-transformations-final-proteins.pdb",
+            )
+
 
 from openeye import oechem
+
+
 def consolidate_protein_snapshots_into_pdb(
-        oemols: List[oechem.OEMol],
-        results_path: str,
-        pdb_filename: Optional[str] = 'transformations-final-proteins.pdb',
+    oemols: List[oechem.OEMol],
+    results_path: str,
+    pdb_filename: Optional[str] = "transformations-final-proteins.pdb",
 ):
     """
     Consolidate protein snapshots into a single file
@@ -404,9 +451,10 @@ def consolidate_protein_snapshots_into_pdb(
 
     # TODO: Replace this with something that writes models as we read them
     # since this is highly memory inefficient and slow
-        
+
     proteins = list()
     from rich.progress import track
+
     for oemol in track(oemols, description="Reading protein snapshots"):
         RUN = oechem.OEGetSDData(oemol, "RUN")
         protein_pdb_filename = os.path.join(
@@ -420,7 +468,7 @@ def consolidate_protein_snapshots_into_pdb(
             continue
 
     if not proteins:
-        return # DEBUG
+        return  # DEBUG
         raise ValueError("No protein snapshots found")
 
     logging.info(f"Writing consolidated snapshots to {pdb_filename}")

--- a/fah_xchem/analysis/website/__init__.py
+++ b/fah_xchem/analysis/website/__init__.py
@@ -201,7 +201,7 @@ def generate_website(
     environment.filters["experimental_data_url"] = experimental_data_url
     environment.filters["smiles_to_filename"] = get_image_filename
 
-    for subdir in ["compounds", "microstates", "transformations"]:
+    for subdir in ["compounds", "microstates", "transformations", "filtered_transformations"]:
         os.makedirs(os.path.join(path, subdir), exist_ok=True)
 
     def write_html(
@@ -297,4 +297,13 @@ def generate_website(
         items=series.transformations,
         items_per_page=items_per_page,
         description="Generating html for transformations index",
+    )
+
+    #TODO use filtered transformation data, currently just a copy of the transformations page
+    _generate_paginated_index(
+    write_html=lambda items, **kwargs: write_html(transformations=items, **kwargs),
+    url_prefix="filtered_transformations",
+    items=series.transformations,
+    items_per_page=items_per_page,
+    description="Generating html for filtered transformations index",
     )

--- a/fah_xchem/analysis/website/__init__.py
+++ b/fah_xchem/analysis/website/__init__.py
@@ -201,7 +201,7 @@ def generate_website(
     environment.filters["experimental_data_url"] = experimental_data_url
     environment.filters["smiles_to_filename"] = get_image_filename
 
-    for subdir in ["compounds", "microstates", "transformations", "filtered_transformations"]:
+    for subdir in ["compounds", "microstates", "transformations", "reliable_transformations"]:
         os.makedirs(os.path.join(path, subdir), exist_ok=True)
 
     def write_html(
@@ -299,11 +299,10 @@ def generate_website(
         description="Generating html for transformations index",
     )
 
-    #TODO use filtered transformation data, currently just a copy of the transformations page
     _generate_paginated_index(
     write_html=lambda items, **kwargs: write_html(transformations=items, **kwargs),
-    url_prefix="filtered_transformations",
+    url_prefix="reliable_transformations",
     items=series.transformations,
     items_per_page=items_per_page,
-    description="Generating html for filtered transformations index",
+    description="Generating html for reliable transformations index",
     )

--- a/fah_xchem/analysis/website/templates/base.html
+++ b/fah_xchem/analysis/website/templates/base.html
@@ -61,7 +61,8 @@ td.thumbnail img {
     ("index.html", "index", "Summary"),
     ("compounds/index.html", "compounds", "Compounds"),
     ("microstates/index.html", "microstates", "Microstates"),
-    ("transformations/index.html", "transformations", "Transformations")
+    ("transformations/index.html", "transformations", "Transformations"),
+    ("filtered_transformations/index.html", "filtered_transformations", "Filtered transformations")
 ] -%}
 
 {% set active_page = active_page | default("index") -%}

--- a/fah_xchem/analysis/website/templates/base.html
+++ b/fah_xchem/analysis/website/templates/base.html
@@ -62,7 +62,7 @@ td.thumbnail img {
     ("compounds/index.html", "compounds", "Compounds"),
     ("microstates/index.html", "microstates", "Microstates"),
     ("transformations/index.html", "transformations", "Transformations"),
-    ("filtered_transformations/index.html", "filtered_transformations", "Filtered transformations")
+    ("reliable_transformations/index.html", "reliable_transformations", "Reliable transformations")
 ] -%}
 
 {% set active_page = active_page | default("index") -%}

--- a/fah_xchem/analysis/website/templates/filtered_transformations/index.html
+++ b/fah_xchem/analysis/website/templates/filtered_transformations/index.html
@@ -20,6 +20,7 @@ Showing {{ start_index }} through {{ end_index }} of {{ series.transformations |
     <th>Convergence <i type="button" class="fa fa-info-circle" data-html="true" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="bottom" data-title="<b>Convergence</b>" data-content="<b>Top plot</b>: Green points represent relative binding free energy (RBFE) estimates from individual iterations (GENs) with a 95% confidence interval (pale green shaded region). Confidence in the RBFE estimate is higher if RBFEs between iterations are in good agreement, ideally falling within the 95% confidence interval. <br /><br /> <b>Lower plot</b>: Binding free energy estimates of solvent (blue) and complex (red) phases."></i></th>
   </tr>
   {% for transformation in transformations %}
+  {% if transformation.transformation.reliable_transform %}
   <tr>
     <td >RUN{{ transformation.transformation.run_id }}</td>
     <td>{{ transformation.transformation.initial_microstate.microstate_id | format_compound_id }}{{ postera.maybe_link(transformation.transformation.initial_microstate.microstate_id) }}</td>
@@ -71,6 +72,7 @@ Showing {{ start_index }} through {{ end_index }} of {{ series.transformations |
       </a>
     </td>
   </tr>
+  {% endif %}
   {% endfor %}
 </table>
 {% endblock %}

--- a/fah_xchem/analysis/website/templates/filtered_transformations/index.html
+++ b/fah_xchem/analysis/website/templates/filtered_transformations/index.html
@@ -1,0 +1,76 @@
+{% extends "base.html" %}
+{% import "postera.html" as postera %}
+{% set active_page = "filtered_transformations" %}
+{% block content %}
+<h3>Filtered Transformations</h3>
+<div class="my-3">
+Showing {{ start_index }} through {{ end_index }} of {{ series.transformations | length }}
+<span style="white-space: nowrap;">
+{% if prev_page %}<a href={{ prev_page }}><i class="fa fa-backward px-1"></i></a>{% endif %}
+{% if next_page %}<a href={{ next_page }}><i class="fa fa-forward px-1"></i></a>{% endif %}
+</span>
+</div>
+<table class="table table-striped table-hover">
+  <tr>
+    <th>RUN <i type="button" class="fa fa-info-circle" data-html="true" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="bottom" data-title="<b>RUN</b>" data-content="The RUN index within the Folding@home project generating this data. <br /><br /> Each RUN consists of a number of independent samples (CLONEs) that are run for multiple iterations (GENs) of nonequilibrium cycles."></i></th>
+    <th colspan=4>Initial microstate <i type="button" class="fa fa-info-circle" data-html="true" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="bottom" data-title="<b>Initial microstate</b>" data-content="The unique identifier of the initial microstate for the relative free energy transformation."></i></th>
+    <th colspan=4>Final microstate <i type="button" class="fa fa-info-circle" data-html="true" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="bottom" data-title="<b>Final microstate</b>" data-content="The unique identifier of the final microstate for the relative free energy transformation."></i></th>
+    <th>ΔΔG / kcal M<sup>-1</sup> <i type="button" class="fa fa-info-circle" data-html="true" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="bottom" data-title="<b>Relative binding free energy</b>" data-content="The computed relative free energy for transforming the initial microstate into the final microstate. <br /><br /> Negative ΔΔG values indicate the final microstate binds more favorably than the initial microstate, while positive ΔΔG values indicate the final microstate binds less favorably. <br /><br /> <b>Note</b>: the ΔΔG values reported here will not be identical to differences in ΔG reported for microstates because DiffNet is used to account for thermodynamic self-consistency in reported microstate absolute ΔG values."></i></th>
+    <th>Work distribution <i type="button" class="fa fa-info-circle" data-html="true" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="bottom" data-title="<b>Work distribution</b>" data-content="The computed work distributions for both the forward (initial -> final) and reverse (final -> initial) transformations. <br /><br /> Multi-modal distributions indicate that that there may be slow conformational degrees of freedom that may hinder convergence, while non-overlapping forward and backward work distributions indicate the transformation is too large to be computed reliably."></i></th>
+    <th>Convergence <i type="button" class="fa fa-info-circle" data-html="true" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="bottom" data-title="<b>Convergence</b>" data-content="<b>Top plot</b>: Green points represent relative binding free energy (RBFE) estimates from individual iterations (GENs) with a 95% confidence interval (pale green shaded region). Confidence in the RBFE estimate is higher if RBFEs between iterations are in good agreement, ideally falling within the 95% confidence interval. <br /><br /> <b>Lower plot</b>: Binding free energy estimates of solvent (blue) and complex (red) phases."></i></th>
+  </tr>
+  {% for transformation in transformations %}
+  <tr>
+    <td >RUN{{ transformation.transformation.run_id }}</td>
+    <td>{{ transformation.transformation.initial_microstate.microstate_id | format_compound_id }}{{ postera.maybe_link(transformation.transformation.initial_microstate.microstate_id) }}</td>
+    <td class="thumbnail">
+      <a href="molecule_images/{{ microstate_detail[transformation.transformation.initial_microstate][1].smiles | smiles_to_filename }}.svg">
+        <img src="molecule_images/{{ microstate_detail[transformation.transformation.initial_microstate][1].smiles | smiles_to_filename }}.svg" alt="molecule" title="{{ microstate_detail[transformation.transformation.initial_microstate][1].smiles }}">
+      </a>
+    </td>
+    <td>
+      <a href="transformations/RUN{{ transformation.transformation.run_id }}/old_ligand.sdf">
+        <button class="btn btn-outline-primary">sdf</button>
+      </a>
+    </td>
+    <td>
+      <a href="transformations/RUN{{ transformation.transformation.run_id }}/old_protein.pdb">
+        <button class="btn btn-outline-primary">pdb</button>
+      </a>
+    </td>
+    <td>{{ transformation.transformation.final_microstate.microstate_id | format_compound_id }}{{ postera.maybe_link(transformation.transformation.final_microstate.microstate_id) }}</td>
+    <td class="thumbnail">
+      <a href="molecule_images/{{ microstate_detail[transformation.transformation.final_microstate][1].smiles | smiles_to_filename }}.svg">
+        <img src="molecule_images/{{ microstate_detail[transformation.transformation.final_microstate][1].smiles | smiles_to_filename }}.svg" alt="molecule" title="{{ microstate_detail[transformation.transformation.final_microstate][1].smiles }}">
+      </a>
+    </td>
+    <td>
+      <a href="transformations/RUN{{ transformation.transformation.run_id }}/new_ligand.sdf">
+        <button class="btn btn-outline-primary">sdf</button>
+      </a>
+    </td>
+    <td>
+      <a href="transformations/RUN{{ transformation.transformation.run_id }}/new_protein.pdb">
+        <button class="btn btn-outline-primary">pdb</button>
+      </a>
+    </td>
+    <td class="binding">
+      <span class="estimate">
+        <span class="point">{{ (transformation.binding_free_energy * KT_KCALMOL) | format_point }}</span>
+        <span class="stderr"> ± {{ (transformation.binding_free_energy * KT_KCALMOL) | format_stderr }}</span>
+      </span>
+    </td>
+    <td class="thumbnail">
+      <a href="transformations/RUN{{ transformation.transformation.run_id }}/works.pdf">
+        <img src="transformations/RUN{{ transformation.transformation.run_id }}/works.png" alt="work distributions">
+      </a>
+    </td>
+    <td class="thumbnail">
+      <a href="transformations/RUN{{ transformation.transformation.run_id }}/convergence.pdf">
+        <img src="transformations/RUN{{ transformation.transformation.run_id }}/convergence.png" alt="convergence plot">
+      </a>
+    </td>
+  </tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/fah_xchem/analysis/website/templates/filtered_transformations/index.html
+++ b/fah_xchem/analysis/website/templates/filtered_transformations/index.html
@@ -20,7 +20,7 @@ Showing {{ start_index }} through {{ end_index }} of {{ series.transformations |
     <th>Convergence <i type="button" class="fa fa-info-circle" data-html="true" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="bottom" data-title="<b>Convergence</b>" data-content="<b>Top plot</b>: Green points represent relative binding free energy (RBFE) estimates from individual iterations (GENs) with a 95% confidence interval (pale green shaded region). Confidence in the RBFE estimate is higher if RBFEs between iterations are in good agreement, ideally falling within the 95% confidence interval. <br /><br /> <b>Lower plot</b>: Binding free energy estimates of solvent (blue) and complex (red) phases."></i></th>
   </tr>
   {% for transformation in transformations %}
-  {% if transformation.transformation.reliable_transform %}
+  {% if transformation.reliable_transformation %}
   <tr>
     <td >RUN{{ transformation.transformation.run_id }}</td>
     <td>{{ transformation.transformation.initial_microstate.microstate_id | format_compound_id }}{{ postera.maybe_link(transformation.transformation.initial_microstate.microstate_id) }}</td>

--- a/fah_xchem/analysis/website/templates/index.html
+++ b/fah_xchem/analysis/website/templates/index.html
@@ -72,6 +72,7 @@
 <ul><li><a href="analysis.json">analysis.json</a></li></ul>
 <h4>PDF summary</h4>
 <ul><li><a href="transformations-final-ligands.pdf">transformations-final-ligands.pdf</a></li></ul>
+<ul><li><a href="reliable-transformations-final-ligands.pdf">reliable-transformations-final-ligands.pdf</a></li></ul>
 <h3>Structures</h3>
 <ul>
   <h4>Proposed ligands</h4>  
@@ -79,8 +80,16 @@
   <li><a href="transformations-final-ligands.sdf">transformations-final-ligands.sdf</a></li>
   <li><a href="transformations-final-ligands.mol2">transformations-final-ligands.mol2</a></li>
   <li><a href="transformations-final-proteins.pdb">transformation-final-proteins.pdb</a></li>
+  <h5>Proposed ligands with reliable transformations</h5>
+  <li><a href="reliable-transformations-final-ligands.csv">reliable-transformations-final-ligands.csv</a></li>
+  <li><a href="reliable-transformations-final-ligands.sdf">reliable-transformations-final-ligands.sdf</a></li>
+  <li><a href="reliable-transformations-final-ligands.mol2">reliable-transformations-final-ligands.mol2</a></li>
+  <li><a href="reliable-transformations-final-proteins.pdb">reliable-transformation-final-proteins.pdb</a></li>
   <h4>Reference ligands</h4>    
   <li><a href="transformations-initial-ligands.mol2">transformation-initial-ligands.mol2</a></li>
   <li><a href="transformations-initial-ligands.sdf">transformation-initial-ligands.sdf</a></li>
+  <h5>Reference ligands with reliable transformations</h5>    
+  <li><a href="reliable-transformations-initial-ligands.mol2">reliable-transformation-initial-ligands.mol2</a></li>
+  <li><a href="reliable-transformations-initial-ligands.sdf">reliable-transformation-initial-ligands.sdf</a></li>
 </ul>
 {% endblock %}

--- a/fah_xchem/analysis/website/templates/reliable_transformations/index.html
+++ b/fah_xchem/analysis/website/templates/reliable_transformations/index.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% import "postera.html" as postera %}
-{% set active_page = "filtered_transformations" %}
+{% set active_page = "reliable_transformations" %}
 {% block content %}
-<h3>Filtered Transformations</h3>
+<h3>Reliable Transformations</h3>
 <div class="my-3">
 Showing {{ start_index }} through {{ end_index }} of {{ series.transformations | length }}
 <span style="white-space: nowrap;">

--- a/fah_xchem/analysis/website/templates/reliable_transformations/index.html
+++ b/fah_xchem/analysis/website/templates/reliable_transformations/index.html
@@ -2,7 +2,7 @@
 {% import "postera.html" as postera %}
 {% set active_page = "reliable_transformations" %}
 {% block content %}
-<h3>Reliable Transformations</h3>
+<h3>Reliable Transformations <i type="button" class="fa fa-info-circle" data-html="true" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="bottom" data-title="<b>Reliable transformations</b>" data-content="This page contains transformations that are deemed reliable based on consistency between GENs."></i></th></h3>
 <div class="my-3">
 Showing {{ start_index }} through {{ end_index }} of {{ series.transformations | length }}
 <span style="white-space: nowrap;">

--- a/fah_xchem/schema.py
+++ b/fah_xchem/schema.py
@@ -125,6 +125,7 @@ class Transformation(Model):
         description="The RUN number corresponding to the Folding@Home directory structure",
     )
     xchem_fragment_id: str = Field(None, description="The XChem fragment screening ID")
+    reliable_transform: bool = Field(False, description="Specify if the transformation is reliable or not")
     initial_microstate: CompoundMicrostate
     final_microstate: CompoundMicrostate
 

--- a/fah_xchem/schema.py
+++ b/fah_xchem/schema.py
@@ -125,7 +125,6 @@ class Transformation(Model):
         description="The RUN number corresponding to the Folding@Home directory structure",
     )
     xchem_fragment_id: str = Field(None, description="The XChem fragment screening ID")
-    reliable_transform: bool = Field("false", description="Specify if the transformation is reliable or not") # JSON boolean
     initial_microstate: CompoundMicrostate
     final_microstate: CompoundMicrostate
 
@@ -167,6 +166,7 @@ class PhaseAnalysis(Model):
 
 class TransformationAnalysis(Model):
     transformation: Transformation
+    reliable_transformation: bool = Field(None, description="Specify if the transformation is reliable or not") # JSON boolean
     binding_free_energy: PointEstimate
     complex_phase: PhaseAnalysis
     solvent_phase: PhaseAnalysis

--- a/fah_xchem/schema.py
+++ b/fah_xchem/schema.py
@@ -125,7 +125,7 @@ class Transformation(Model):
         description="The RUN number corresponding to the Folding@Home directory structure",
     )
     xchem_fragment_id: str = Field(None, description="The XChem fragment screening ID")
-    reliable_transform: bool = Field(False, description="Specify if the transformation is reliable or not")
+    reliable_transform: bool = Field("false", description="Specify if the transformation is reliable or not") # JSON boolean
     initial_microstate: CompoundMicrostate
     final_microstate: CompoundMicrostate
 


### PR DESCRIPTION
## Description
Addresses #109. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Create new "Filtered transformations" tab for the dashboard.
  - [x] Make sure the "Filtered transformations" tab contains the correctly labelled reliable transforms.
  - [x] Add a command-line flag that specifies how many std errors to use for filtering.
  - [ ] Check descriptions for new "Reliable Transformations" page are sensible.
  - [ ] Check all output files (CSV, SDF, MOL2, PDB) are correct.

## Status
- [ ] Ready to go