### PR TITLE
Added `overwrite` flag; by default run-level snapshots and plots not regenerated

### DIFF
--- a/fah_xchem/analysis/__init__.py
+++ b/fah_xchem/analysis/__init__.py
@@ -179,6 +179,7 @@ def generate_artifacts(
     plots: bool = True,
     report: bool = True,
     website: bool = True,
+    overwrite: bool = False,
 ) -> None:
 
     complex_project_dir = os.path.join(
@@ -199,6 +200,7 @@ def generate_artifacts(
             max_binding_free_energy=config.max_binding_free_energy,
             cache_dir=cache_dir,
             num_procs=num_procs,
+            overwrite=overwrite,
         )
 
     if plots:
@@ -208,6 +210,7 @@ def generate_artifacts(
             timestamp=timestamp,
             output_dir=output_dir,
             num_procs=num_procs,
+            overwrite=overwrite,
         )
 
     if snapshots and report:

--- a/fah_xchem/analysis/plots.py
+++ b/fah_xchem/analysis/plots.py
@@ -450,8 +450,9 @@ def plot_bootstrapped_clones(
     return fig
 
 
-def _plot_updated_timestamp(timestamp: dt.datetime) -> None:
-    fig = plt.gcf()
+def _plot_updated_timestamp(timestamp: dt.datetime, fig: plt.Figure = None) -> None:
+    if fig is None:
+        fig = plt.gcf()
     fig.text(
         0.5,
         0.03,
@@ -490,10 +491,10 @@ def _save_table_pdf(path: str, name: str):
             logging.warning("Failed to save pdf table")
 
 
-@contextmanager
 def save_plot(
     path: str,
     name: str,
+    fig: plt.Figure,
     file_formats: Iterable[str] = ("png", "pdf"),
     timestamp: Optional[dt.datetime] = None,
 ) -> Generator:
@@ -516,33 +517,38 @@ def save_plot(
 
     Examples
     --------
-    >>> with save_plot('example/plots', 'test_plot', 'png'):
-    >>>     plt.plot(np.cos(np.linspace(-np.pi, np.pi)))
-    >>>     plt.title("My cool plot")
+    >>> fig = plt.plot(np.cos(np.linspace(-np.pi, np.pi)))
+    >>> fig.title("My cool plot")
+    >>> save_plot('example/plots', 'test_plot', fig, 'png'):
     """
+    outfiles = [os.path.join(path, os.extsep.join([name, file_format]))
+                for file_format in file_formats]
 
-    try:
-        outfiles = [os.path.join(path, os.extsep.join([name, file_format]))
-                    for file_format in file_formats]
-        yield outfiles
+    if timestamp is not None:
+        fig.tight_layout(rect=(0, 0.05, 1, 1))  # leave space for timestamp
+        _plot_updated_timestamp(timestamp, fig)
+    else:
+        fig.tight_layout()
 
-        if timestamp is not None:
-            plt.tight_layout(rect=(0, 0.05, 1, 1))  # leave space for timestamp
-            _plot_updated_timestamp(timestamp)
-        else:
-            plt.tight_layout()
+    # Make sure the directory exists
+    os.makedirs(path, exist_ok=True)
 
-        # Make sure the directory exists
-        os.makedirs(path, exist_ok=True)
+    for outfile in outfiles:
+        fig.savefig(
+            outfile,
+            transparent=True,
+        )
 
-        for outfile in outfiles:
-            plt.savefig(
-                outfile,
-                transparent=True,
-            )
+    plt.close(fig=fig)
 
-    finally:
-        plt.close()
+
+def _plot_to_file_mapping(
+    path: str,
+    name: str,
+    file_formats: Iterable[str] = ("png", "pdf"),
+) -> List:
+    return [os.path.join(path, os.extsep.join([name, file_format]))
+            for file_format in file_formats]
 
 
 def generate_transformation_plots(
@@ -552,17 +558,22 @@ def generate_transformation_plots(
 ):
 
     run_id = transformation.transformation.run_id
+
+    plot_output_dir = os.path.join(output_dir, "transformations", f"RUN{run_id}")
     save_transformation_plot = partial(
-        save_plot, path=os.path.join(output_dir, "transformations", f"RUN{run_id}")
+        save_plot, path=plot_output_dir
     )
 
-    with save_transformation_plot(name="works") as outfiles:
+    name = "works"
+    # check if output files all exist; if so, skip unless we are told not to
+    skip = False
+    if not overwrite:
+        outfiles = _plot_to_file_mapping(path=plot_output_dir, name=name)
+        if all(map(os.path.exists, outfiles)):
+            skip = True
 
-        # check if output files all exist; if so, skip unless we are told not to
-        if not overwrite:
-            if all(map(os.path.exists, outfiles)):
-                continue
 
+    if not skip:
         fig = plot_work_distributions(
             complex_forward_works=[
                 work.forward
@@ -588,14 +599,17 @@ def generate_transformation_plots(
             solvent_delta_f=transformation.solvent_phase.free_energy.delta_f.point,
         )
         fig.suptitle(f"RUN{run_id}")
+        save_transformation_plot(name=name, fig=fig)
 
-    with save_transformation_plot(name="convergence") as outfiles:
+    name = "convergence"
+    # check if output files all exist; if so, skip unless we are told not to
+    skip = False
+    if not overwrite:
+        outfiles = _plot_to_file_mapping(path=plot_output_dir, name=name)
+        if all(map(os.path.exists, outfiles)):
+            skip = True
 
-        # check if output files all exist; if so, skip unless we are told not to
-        if not overwrite:
-            if all(map(os.path.exists, outfiles)):
-                continue
-
+    if not skip:
         # Filter to GENs for which free energy calculation is available
         complex_gens = [
             (gen.gen, gen.free_energy)
@@ -619,14 +633,17 @@ def generate_transformation_plots(
             binding_delta_f_err=transformation.binding_free_energy.stderr,
         )
         fig.suptitle(f"RUN{run_id}")
+        save_transformation_plot(name=name, fig=fig)
 
-    with save_transformation_plot(name="bootstrapped-CLONEs") as outfiles:
+    name = "bootstrapped-CLONEs"
+    # check if output files all exist; if so, skip unless we are told not to
+    skip = False
+    if not overwrite:
+        outfiles = _plot_to_file_mapping(path=plot_output_dir, name=name)
+        if all(map(os.path.exists, outfiles)):
+            skip = True
 
-        # check if output files all exist; if so, skip unless we are told not to
-        if not overwrite:
-            if all(map(os.path.exists, outfiles)):
-                continue
-
+    if not skip:
         # Gather CLONES per GEN for run
         clones_per_gen = min(
             [
@@ -648,6 +665,7 @@ def generate_transformation_plots(
             n_gens=n_gens,
         )
         fig.suptitle(f"RUN{run_id}")
+        save_transformation_plot(name=name, fig=fig)
 
 
 def generate_plots(

--- a/fah_xchem/app.py
+++ b/fah_xchem/app.py
@@ -143,6 +143,7 @@ def generate_artifacts(
     website: bool = True,
     log: str = "WARN",
     fragalysis_config: Optional[str] = None,
+    overwrite: bool = False,
 ) -> None:
     """
     Given results of free energy analysis as JSON, generate analysis
@@ -186,6 +187,11 @@ def generate_artifacts(
         Logging level
     fragalysis_config : str, optional
         File containing information for Fragalysis upload as JSON-encoded :class: ~`fah_xchem.schema.FragalysisConfig`
+    overwrite : bool
+        If `True`, write over existing output files if present.
+        Otherwise, skip writing output files for a given transformation when already present.
+        Assumes that for a given `run_id` the output files do not ever change;
+        does *no* checking that files wouldn't be different if inputs for a given `run_id` have changed.
     """
 
     logging.basicConfig(level=getattr(logging, log.upper()))
@@ -212,6 +218,7 @@ def generate_artifacts(
         report=report,
         website=website,
         fragalysis_config=fragalysis_config,
+        overwrite=overwrite,
     )
 
 


### PR DESCRIPTION
## Description
This PR addresses #124.

Added the `--overwrite` flag to `fah-xchem generate-artifacts` that defaults to `False`. By default this command will now only regenerate snapshots and figures for `run` directories that are missing a file generated by this approach. 

The intent is that this should cut down on the run time of `fah-xchem generate-artifacts`, since run data shouldn't change and therefore most artifacts don't ever need to be remade.

This new behavior can be overridden with `--overwrite=True`, giving the existing behavior.

## Todos
  - [ ] Add tests for new behavior, if possible at this time

## Status
- [ ] Ready to go