### PR TITLE
Changed default `max_n_devs` from 5 to 100

### DIFF
--- a/fah_xchem/analysis/free_energy.py
+++ b/fah_xchem/analysis/free_energy.py
@@ -50,7 +50,7 @@ def _mask_outliers(
 def _filter_work_values(
     works: np.ndarray,
     max_value: float = 1e4,
-    max_n_devs: float = 5,
+    max_n_devs: float = 100,
     min_sample_size: int = 10,
 ) -> np.ndarray:
     """Remove pairs of works when either is determined to be an outlier.


### PR DESCRIPTION
## Description
This is a change from @jchodera from his production usage. This default value of `max_n_devs=100` will retain all values within 100 standard deviations from the mean, filtering only extreme outliers.

## Status
- [ ] Ready to go