### PR TITLE
Setting build matrix to match NEP29 schedule

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
See here for schedule: https://numpy.org/neps/nep-0029-deprecation_policy.html

## Status
- [ ] Ready to go