### PR TITLE
Refactored website generation under WebsiteArtifactory

### DIFF
--- a/fah_xchem/analysis/__init__.py
+++ b/fah_xchem/analysis/__init__.py
@@ -33,7 +33,7 @@ from .free_energy import compute_relative_free_energy, InsufficientDataError
 from .plots import generate_plots
 from .report import generate_report, gens_are_consistent
 from .structures import generate_representative_snapshots
-from .website import generate_website
+from .website import WebsiteArtifactory
 
 
 EXP_DDG_IJ_ERR = 0.2  # TODO check this is correct
@@ -337,6 +337,7 @@ def generate_artifacts(
     output_dir: str,
     base_url: str,
     config: AnalysisConfig,
+    server: FahConfig,
     cache_dir: Optional[str] = None,
     num_procs: Optional[int] = None,
     snapshots: bool = True,
@@ -396,9 +397,11 @@ def generate_artifacts(
 
     if website:
         logging.info("Generating website")
-        generate_website(
-            series=series,
-            path=output_dir,
-            timestamp=timestamp,
-            base_url=base_url,
-        )
+        waf = WebsiteArtifactory(
+                base_url=base_url,
+                path=output_dir,
+                series=series,
+                timestamp=timestamp,
+                fah_ws_api_url=server.api_url)
+
+        waf.generate_website()

--- a/fah_xchem/analysis/filters.py
+++ b/fah_xchem/analysis/filters.py
@@ -1,0 +1,28 @@
+"""Detailed-chemistry and molecular characterizers used for filtering analysis outputs.
+
+"""
+
+from ..schema import CompoundMicrostate, CompoundSeriesAnalysis
+
+
+class Racemic:
+
+    def __init__(
+            self, 
+            series: CompoundSeriesAnalysis
+            ):
+
+        self.series = series
+
+        # Transformations not involving racemates
+        # TODO: Consider changing `series.compounds` to be a dict with `compound_id` as keys
+        self.microstates = {
+            compound.metadata.compound_id: compound.microstates
+            for compound in series.compounds
+        }
+
+    def compound_microstate(
+            self,
+            compound_microstate: CompoundMicrostate, 
+            ):
+        return True if (len(self.microstates[compound_microstate.compound_id]) > 1) else False

--- a/fah_xchem/analysis/plots.py
+++ b/fah_xchem/analysis/plots.py
@@ -20,6 +20,7 @@ from ..schema import (
     TransformationAnalysis,
 )
 from .constants import KT_KCALMOL
+from .filters import Racemic
 from arsenic import plotting
 
 
@@ -807,33 +808,7 @@ def generate_plots(
     # this needs to be plotted last as the figure isn't cleared by default in Arsenic
     # TODO generate time stamp
 
-    # All transformations
-    plot_retrospective(
-        output_dir=output_dir,
-        transformations=series.transformations,
-        filename="retrospective-transformations-all",
-    )
-
-    # Reliable subset of transformations
-    plot_retrospective(
-        output_dir=output_dir,
-        transformations=[
-            transformation
-            for transformation in series.transformations
-            if transformation.reliable_transformation
-        ],
-        filename="retrospective-transformations-reliable",
-    )
-
-    # Transformations not involving racemates
-    # TODO: Find a simpler way to filter non-racemates
-    nmicrostates = {
-        compound.metadata.compound_id: len(compound.microstates)
-        for compound in series.compounds
-    }
-
-    def is_racemate(microstate):
-        return True if (nmicrostates[microstate.compound_id] > 1) else False
+    racemic_filter = Racemic(series)
 
     plot_retrospective(
         output_dir=output_dir,
@@ -841,8 +816,8 @@ def generate_plots(
             transformation
             for transformation in series.transformations
             if (
-                not is_racemate(transformation.transformation.initial_microstate)
-                and not is_racemate(transformation.transformation.final_microstate)
+                not racemic_filter.compound_microstate(transformation.transformation.initial_microstate)
+                and not racemic_filter.compound_microstate(transformation.transformation.final_microstate)
             )
         ],
         filename="retrospective-transformations-noracemates",

--- a/fah_xchem/analysis/website/templates/retrospective_transformations/index.html
+++ b/fah_xchem/analysis/website/templates/retrospective_transformations/index.html
@@ -3,17 +3,11 @@
 {% set active_page = "retrospective_transformations" %}
 {% block content %}
 <h3>Retrospective Transformations <i type="button" class="fa fa-info-circle" data-html="true" data-container="body" data-toggle="popover" data-trigger="hover" data-placement="bottom" data-title="<b>Retrospective transformations</b>" data-content="This page contains a retrospective analysis of the accuracy of individual transformations (without DiffNet MLE estimates) compared with experimental data."></i></th></h3>
-<a href="retrospective-transformations-all.png">
-  <img src="retrospective-transformations-all.png" alt="retrospective transformations plot - all transformations">
-</a>
-<a href="retrospective-transformations-reliable.png">
-  <img src="retrospective-transformations-reliable.png" alt="retrospective transformations plot - reliable transformations">
-</a>
 <a href="retrospective-transformations-noracemates.png">
   <img src="retrospective-transformations-noracemates.png" alt="retrospective transformations plot - no racemates">
 </a>
 <div class="my-3">
-Showing {{ start_index }} through {{ end_index }} of {{ series.transformations | length }}
+Showing {{ start_index }} through {{ end_index }} of {{ transformations | length }}
 <span style="white-space: nowrap;">
 {% if prev_page %}<a href={{ prev_page }}><i class="fa fa-backward px-1"></i></a>{% endif %}
 {% if next_page %}<a href={{ next_page }}><i class="fa fa-forward px-1"></i></a>{% endif %}

--- a/fah_xchem/app.py
+++ b/fah_xchem/app.py
@@ -142,6 +142,7 @@ def generate_artifacts(
     compound_series_analysis_file: str,
     fah_projects_dir: str,
     fah_data_dir: str,
+    fah_api_url: str,
     output_dir: str = "results",
     base_url: str = "/",
     config_file: Optional[str] = None,
@@ -174,6 +175,8 @@ def generate_artifacts(
         Path to directory containing Folding@home project definitions
     fah_data_dir : str
         Path to directory containing Folding@home project result data
+    fah_api_url : str
+        URL for work server API
     output_dir : str, optional
         Write output here
     base_url : str, optional
@@ -215,6 +218,11 @@ def generate_artifacts(
     with open(compound_series_analysis_file, "r") as infile:
         tsa = TimestampedAnalysis.parse_obj(json.load(infile))
 
+    server = FahConfig(
+            projects_dir=fah_projects_dir,
+            data_dir=fah_data_dir,
+            api_url=fah_api_url)
+
     return fah_xchem.analysis.generate_artifacts(
         series=tsa.series,
         timestamp=tsa.as_of,
@@ -223,6 +231,7 @@ def generate_artifacts(
         output_dir=output_dir,
         base_url=base_url,
         config=config,
+        server=server,
         cache_dir=cache_dir,
         num_procs=num_procs,
         snapshots=snapshots,

--- a/fah_xchem/schema.py
+++ b/fah_xchem/schema.py
@@ -196,6 +196,7 @@ class CompoundAnalysis(Model):
 
 class CompoundSeriesAnalysis(Model):
     metadata: CompoundSeriesMetadata
+    # TODO: perhaps make this a dict with `metadata.compound_id` as key?
     compounds: List[CompoundAnalysis]
     transformations: List[TransformationAnalysis]
 
@@ -206,8 +207,9 @@ class AnalysisConfig(Model):
 
 
 class FahConfig(Model):
-    projects_dir: str = "projects"
-    data_dir: str = "data"
+    projects_dir: str = None
+    data_dir: str = None
+    api_url: str = None
 
 
 class FragalysisConfig(Model):


### PR DESCRIPTION
Addresses #141, #149.

Reduced the complexity of the giant `generate_website` function by replacing it with the `WebsiteArtifactory` class. Separated individual tabs of site into their own calls for scope encapsulation. Aim is to make it easier to chase down subtle issues, such as why we don't have pagination arrows for the retrospective tab.

Also, separating configuration from the generation call with attributes on the object reduces the number of args that must be passed through to called methods, and avoids the workaround used previously of functions defined within the function to take advantage of its scope.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] unit tests for the `WebsiteArtifactory`

## Status
- [ ] Ready to go