### PR TITLE
CDDData : experimental compound data export

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -50,6 +50,8 @@ jobs:
         df -h
         ulimit -a
 
+        echo "Trigger: ${{ github.event.action }}"
+
     - name: Cache conda
       uses: actions/cache@v2
       env:
@@ -96,6 +98,7 @@ jobs:
       shell: bash -l {0}
 
       run: |
+        echo "${{ github.event.action }}"
         pytest -v --cov=fah_xchem --cov-report=xml --color=yes fah_xchem
 
     - name: CodeCov

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -98,7 +98,7 @@ jobs:
       shell: bash -l {0}
 
       run: |
-        TRIGGER = "${{ github.event.action }}"
+        TRIGGER="${{ github.event.action }}"
 
         # UNCOMMENT AFTER MERGE OF 172, remove force of --runslow below
         #if [ "${TRIGGER}" != "synchronize"]

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -100,10 +100,12 @@ jobs:
       run: |
         TRIGGER = "${{ github.event.action }}"
 
-        if [ "${TRIGGER}" != "synchronize"]
-        then
-          ADDITIONAL_ARGS="--runslow ${ADDITIONAL_ARGS}"
-        fi
+        # UNCOMMENT AFTER MERGE OF 172, remove force of --runslow below
+        #if [ "${TRIGGER}" != "synchronize"]
+        #then
+        #  ADDITIONAL_ARGS="--runslow ${ADDITIONAL_ARGS}"
+        #fi
+        ADDITIONAL_ARGS="--runslow ${ADDITIONAL_ARGS}"
 
         pytest -v --cov=fah_xchem --cov-report=xml --color=yes ${ADDITIONAL_ARGS} fah_xchem
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -35,6 +35,10 @@ jobs:
           - ubuntu-latest
           #- windows-latest
         python-version: [3.7, 3.8, 3.9]
+    env:
+      OE_LICENSE: ${{ github.workspace }}/oe_license.txt
+      CDD_VAULT_TOKEN: ${{ secrets.CDD_VAULT_TOKEN }}
+      CDD_VAULT_NUM: ${{ secrets.CDD_VAULT_NUM }}
 
     steps:
     - uses: actions/checkout@v1
@@ -69,6 +73,14 @@ jobs:
         use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
         mamba-version: "*"
         use-mamba: true
+
+    - name: Decrypt OpenEye license
+      shell: bash -l {0}
+      env:
+        OE_LICENSE_TEXT: ${{ secrets.OE_LICENSE }}
+      run: |
+        echo "${OE_LICENSE_TEXT}" > ${OE_LICENSE}
+        python -c "import openeye; assert openeye.oechem.OEChemIsLicensed(), 'OpenEye license checks failed!'"
 
     - name: Install package
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -98,8 +98,14 @@ jobs:
       shell: bash -l {0}
 
       run: |
-        echo "${{ github.event.action }}"
-        pytest -v --cov=fah_xchem --cov-report=xml --color=yes fah_xchem
+        TRIGGER = "${{ github.event.action }}"
+
+        if [ "${TRIGGER}" != "synchronize"]
+        then
+          ADDITIONAL_ARGS="--runslow ${ADDITIONAL_ARGS}"
+        fi
+
+        pytest -v --cov=fah_xchem --cov-report=xml --color=yes ${ADDITIONAL_ARGS} fah_xchem
 
     - name: CodeCov
       uses: codecov/codecov-action@v1

--- a/fah_xchem/cli.py
+++ b/fah_xchem/cli.py
@@ -178,8 +178,15 @@ def update_experimental_data(
 
 
 @click.group()
-def cli():
-    ...
+@click.option(
+    "-l",
+    "--loglevel",
+    type=str,
+    default="WARN",
+    help="Logging level to use for execution",
+)
+def cli(loglevel):
+    logging.basicConfig(level=getattr(logging, loglevel.upper()))
 
 
 @cli.group()
@@ -515,13 +522,6 @@ def compound_series_generate():
     type=Path,
     help="If given, load experimental compound data and update compound `experimental_data` dictionaries",
 )
-@click.option(
-    "-l",
-    "--loglevel",
-    type=str,
-    default="WARN",
-    help="Logging level to use for execution",
-)
 def compound_series_analyze(
     compound_series_file,
     compound_series_analysis_file,
@@ -531,7 +531,6 @@ def compound_series_analyze(
     nprocs,
     max_transformations,
     experimental_data_file,
-    loglevel,
 ):
     """
     Run free energy analysis on COMPOUND-SERIES-FILE with `CompoundSeries` data
@@ -540,8 +539,6 @@ def compound_series_analyze(
 
     """
     from .analysis import analyze_compound_series
-
-    logging.basicConfig(level=getattr(logging, loglevel.upper()))
 
     compound_series = _get_config(
         CompoundSeries, compound_series_file, "compound series"
@@ -654,13 +651,6 @@ def artifacts():
     help="Whether to generate HTML for static site",
 )
 @click.option(
-    "-l",
-    "--loglevel",
-    type=str,
-    default="WARN",
-    help="Logging level to use for execution",
-)
-@click.option(
     "--overwrite",
     is_flag=True,
     help=(
@@ -685,7 +675,6 @@ def artifacts_generate(
     plots,
     report,
     website,
-    loglevel,
     overwrite,
 ):
     """
@@ -701,8 +690,6 @@ def artifacts_generate(
 
     """
     from .analysis import generate_artifacts
-
-    logging.basicConfig(level=getattr(logging, loglevel.upper()))
 
     config = _get_config(AnalysisConfig, config_file, "analysis configuration")
 

--- a/fah_xchem/cli.py
+++ b/fah_xchem/cli.py
@@ -252,8 +252,8 @@ def retrieve_molecule_data(ctx):
 
 
 @cdd.command()
-@click.option("-i", "--protocol-id", type=str, multiple=True)
-@click.option("-m", "--molecules", is_flag=True)
+@click.option("-i", "--protocol-id", type=str, multiple=True, help="Protocol IDs from given CDD vault to retrieve")
+@click.option("-m", "--molecules", is_flag=True, help="If included, also retrieve molecule data at the same time as protocols")
 @click.pass_context
 def retrieve_protocol_data(ctx, protocol_id, molecules):
     """Get protocol data from CDD and place in DATA-DIR.
@@ -269,7 +269,7 @@ def retrieve_protocol_data(ctx, protocol_id, molecules):
 
 
 @cdd.command()
-@click.option("-i", "--protocol-id", type=str, multiple=True)
+@click.option("-i", "--protocol-id", type=str, multiple=True, required=True, help="Protocol IDs from given CDD vault to include")
 @click.argument("experimental_compound_data_file", type=Path)
 @click.pass_context
 def generate_experimental_compound_data(

--- a/fah_xchem/cli.py
+++ b/fah_xchem/cli.py
@@ -252,8 +252,19 @@ def retrieve_molecule_data(ctx):
 
 
 @cdd.command()
-@click.option("-i", "--protocol-id", type=str, multiple=True, help="Protocol IDs from given CDD vault to retrieve")
-@click.option("-m", "--molecules", is_flag=True, help="If included, also retrieve molecule data at the same time as protocols")
+@click.option(
+    "-i",
+    "--protocol-id",
+    type=str,
+    multiple=True,
+    help="Protocol IDs from given CDD vault to retrieve",
+)
+@click.option(
+    "-m",
+    "--molecules",
+    is_flag=True,
+    help="If included, also retrieve molecule data at the same time as protocols",
+)
 @click.pass_context
 def retrieve_protocol_data(ctx, protocol_id, molecules):
     """Get protocol data from CDD and place in DATA-DIR.
@@ -269,7 +280,14 @@ def retrieve_protocol_data(ctx, protocol_id, molecules):
 
 
 @cdd.command()
-@click.option("-i", "--protocol-id", type=str, multiple=True, required=True, help="Protocol IDs from given CDD vault to include")
+@click.option(
+    "-i",
+    "--protocol-id",
+    type=str,
+    multiple=True,
+    required=True,
+    help="Protocol IDs from given CDD vault to include",
+)
 @click.argument("experimental_compound_data_file", type=Path)
 @click.pass_context
 def generate_experimental_compound_data(

--- a/fah_xchem/external/base.py
+++ b/fah_xchem/external/base.py
@@ -9,6 +9,9 @@ from rich.progress import track
 class ExternalData(BaseModel):
     """Mixin class for external data interfaces."""
 
+    class Config:
+        extra = "allow"
+
     data_dir: Path = Field(
         ...,
         description="Data directory; retrieved data will be deposited here, can be pre-existing",

--- a/fah_xchem/external/cdd.py
+++ b/fah_xchem/external/cdd.py
@@ -24,12 +24,14 @@ class FailedExportError(Exception):
 
 
 class ProtocolData(abc.ABC):
-
     def __init__(self, cdddata):
         self.cdddata = cdddata
 
     def __repr__(self):
-        protocol_ids = [i.parent.name for i in self.cdddata.protocols_dir.glob(f'*/{self._filename}')]
+        protocol_ids = [
+            i.parent.name
+            for i in self.cdddata.protocols_dir.glob(f"*/{self._filename}")
+        ]
         return f"<protocol ids: {protocol_ids}>"
 
     def __getitem__(self, protocol_id):
@@ -46,11 +48,11 @@ class ProtocolData(abc.ABC):
 
 
 class ProtocolDefs(ProtocolData):
-    _filename = 'protocol-defs.json'
+    _filename = "protocol-defs.json"
 
 
 class ProtocolRecords(ProtocolData):
-    _filename = 'protocol-records.json'
+    _filename = "protocol-records.json"
 
 
 class CDDData(ExternalData):
@@ -72,7 +74,6 @@ class CDDData(ExternalData):
 
     _protocol_processing_map = {"49439": "_process_fluorescence_IC50"}
 
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -93,7 +94,9 @@ class CDDData(ExternalData):
 
         """
         if (self.vault_num is None) or (self.vault_token is None):
-            raise ValueError("Both `vault_num` and `vault_token` attributes must be set to use this method")
+            raise ValueError(
+                "Both `vault_num` and `vault_token` attributes must be set to use this method"
+            )
 
         # retrieve protocol definitions
         headers = {"X-CDD-token": self.vault_token}
@@ -133,9 +136,7 @@ class CDDData(ExternalData):
         first = True
         while any([status != "finished" for status in statuses.values()]):
             for name, export_id in export_ids.items():
-                url = (
-                    f"{self.base_url}/{self.vault_num}/export_progress/{export_id}"
-                )
+                url = f"{self.base_url}/{self.vault_num}/export_progress/{export_id}"
                 response = requests.get(url, headers=headers)
 
                 # to view the status, use:
@@ -162,13 +163,13 @@ class CDDData(ExternalData):
             )
 
         logging.info("CDDData : Retrieving finished export(s)")
-        #text.append(" --> Retrieving finished export(s)", style="bold green")
+        # text.append(" --> Retrieving finished export(s)", style="bold green")
         exports = {}
         for name, export_id in export_ids.items():
             url = f"{self.base_url}/{self.vault_num}/exports/{export_id}"
             exports[name] = requests.get(url, headers=headers)
 
-        #text.append(" --> Done", style="bold blue")
+        # text.append(" --> Done", style="bold blue")
 
         return exports
 
@@ -236,7 +237,9 @@ class CDDData(ExternalData):
         """
 
         if (self.vault_num is None) or (self.vault_token is None):
-            raise ValueError("Both `vault_num` and `vault_token` attributes must be set to use this method")
+            raise ValueError(
+                "Both `vault_num` and `vault_token` attributes must be set to use this method"
+            )
 
         results = self._get_protocol_data(protocol_ids, molecules=molecules)
 
@@ -293,7 +296,9 @@ class CDDData(ExternalData):
 
         """
         if (self.vault_num is None) or (self.vault_token is None):
-            raise ValueError("Both `vault_num` and `vault_token` attributes must be set to use this method")
+            raise ValueError(
+                "Both `vault_num` and `vault_token` attributes must be set to use this method"
+            )
 
         self.data_dir.mkdir(parents=True, exist_ok=True)
 

--- a/fah_xchem/external/tests/test_cdd.py
+++ b/fah_xchem/external/tests/test_cdd.py
@@ -15,16 +15,22 @@ from fah_xchem.external.cdd import CDDData
     reason="require both CDD_VAULT_TOKEN and CDD_VAULT_NUM to run CDD tests",
 )
 class TestCDDData:
-    @pytest.fixture
-    def cdddata(self, tmpdir):
-        with tmpdir.as_cwd():
-            vault_token = os.environ["CDD_VAULT_TOKEN"]
-            vault_num = os.environ["CDD_VAULT_NUM"]
+    @pytest.fixture(scope='class')
+    def cdddata(self, tmpdir_factory):
 
-            cdd = CDDData(data_dir=Path("cdd-data").absolute(), vault_token=vault_token)
+        data_dir = tmpdir_factory.mktemp('cdd-data')
+
+        vault_token = os.environ["CDD_VAULT_TOKEN"]
+        vault_num = os.environ["CDD_VAULT_NUM"]
+
+        cdd = CDDData(data_dir=os.path.abspath(data_dir), vault_token=vault_token)
+
+        protocol_ids = [cdd.fluorescence_IC50_protocol_id]
+        cdd.retrieve_protocol_data(protocol_ids, molecules=True)
 
         return cdd
 
+    @pytest.mark.skip("not testing for now as this adds substantial wait time to test suite")
     def test_retrieve_molecule_data(self, cdddata):
         cdddata.retrieve_molecule_data()
 
@@ -35,6 +41,7 @@ class TestCDDData:
 
         assert all([mol["class"] == "molecule" for mol in molecules["objects"]])
 
+    @pytest.mark.skip("not testing for now as this adds substantial wait time to test suite")
     def test_retrieve_protocol_data(self, cdddata):
         protocol_ids = [cdddata.fluorescence_IC50_protocol_id]
         cdddata.retrieve_protocol_data(protocol_ids)
@@ -77,8 +84,9 @@ class TestCDDData:
         )
 
     def test_retrieve_protocol_data_with_molecules(self, cdddata):
-        protocol_ids = [cdddata.fluorescence_IC50_protocol_id]
-        cdddata.retrieve_protocol_data(protocol_ids, molecules=True)
+        # already performed in fixture
+        #protocol_ids = [cdddata.fluorescence_IC50_protocol_id]
+        #cdddata.retrieve_protocol_data(protocol_ids, molecules=True)
 
         assert (cdddata.data_dir / "molecules.json").exists()
 
@@ -93,7 +101,7 @@ class TestCDDData:
             cdddata.data_dir / "protocols" / cdddata.fluorescence_IC50_protocol_id
         ).exists()
 
-        assert {"protocol-data.json", "protocol-defs.json"} == {
+        assert {"protocol-records.json", "protocol-defs.json"} == {
             p.name
             for p in (
                 cdddata.protocols_dir / cdddata.fluorescence_IC50_protocol_id
@@ -103,7 +111,7 @@ class TestCDDData:
         with open(
             cdddata.protocols_dir
             / cdddata.fluorescence_IC50_protocol_id
-            / "protocol-data.json",
+            / "protocol-records.json",
             "r",
         ) as f:
             protocol_data = json.load(f)
@@ -123,3 +131,30 @@ class TestCDDData:
                 for p in protocol_defs["readout_definitions"]
             ]
         )
+
+    def test_generate_experimental_compound_data(self, cdddata):
+        protocol_ids = [cdddata.fluorescence_IC50_protocol_id]
+
+        # already performed in fixture
+        #cdddata.retrieve_protocol_data(protocol_ids, molecules=True)
+
+        ec = cdddata.generate_experimental_compound_data(protocol_ids)
+
+        # test that the fields indicating variety of compound are mutually exclusive in the data
+        for compound in ec.compounds:
+            compound_varieties = [compound.racemic,
+                                  compound.achiral,
+                                  compound.absolute_stereochemistry_enantiomerically_pure,
+                                  compound.relative_stereochemistry_enantiomerically_pure]
+
+            if compound.smiles is not None:
+                assert sum(compound_varieties) == 1
+            else:
+                assert sum(compound_varieties) == 0
+
+            # here we check that pIC50s are within a typical range
+            pIC50 = compound.experimental_data.get('pIC50')
+            if pIC50:
+                assert 3.0 < pIC50 < 8.0
+
+        assert True

--- a/fah_xchem/external/tests/test_cdd.py
+++ b/fah_xchem/external/tests/test_cdd.py
@@ -10,6 +10,7 @@ import pytest
 from fah_xchem.external.cdd import CDDData
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(
     (("CDD_VAULT_TOKEN" not in os.environ) and ("CDD_VAULT_NUM" not in os.environ)),
     reason="require both CDD_VAULT_TOKEN and CDD_VAULT_NUM to run CDD tests",
@@ -23,7 +24,7 @@ class TestCDDData:
         vault_token = os.environ["CDD_VAULT_TOKEN"]
         vault_num = os.environ["CDD_VAULT_NUM"]
 
-        cdd = CDDData(data_dir=os.path.abspath(data_dir), vault_token=vault_token)
+        cdd = CDDData(data_dir=os.path.abspath(data_dir), vault_num=vault_num, vault_token=vault_token)
 
         protocol_ids = [cdd.fluorescence_IC50_protocol_id]
         cdd.retrieve_protocol_data(protocol_ids, molecules=True)

--- a/fah_xchem/external/tests/test_cdd.py
+++ b/fah_xchem/external/tests/test_cdd.py
@@ -16,22 +16,28 @@ from fah_xchem.external.cdd import CDDData
     reason="require both CDD_VAULT_TOKEN and CDD_VAULT_NUM to run CDD tests",
 )
 class TestCDDData:
-    @pytest.fixture(scope='class')
+    @pytest.fixture(scope="class")
     def cdddata(self, tmpdir_factory):
 
-        data_dir = tmpdir_factory.mktemp('cdd-data')
+        data_dir = tmpdir_factory.mktemp("cdd-data")
 
         vault_token = os.environ["CDD_VAULT_TOKEN"]
         vault_num = os.environ["CDD_VAULT_NUM"]
 
-        cdd = CDDData(data_dir=os.path.abspath(data_dir), vault_num=vault_num, vault_token=vault_token)
+        cdd = CDDData(
+            data_dir=os.path.abspath(data_dir),
+            vault_num=vault_num,
+            vault_token=vault_token,
+        )
 
         protocol_ids = [cdd.fluorescence_IC50_protocol_id]
         cdd.retrieve_protocol_data(protocol_ids, molecules=True)
 
         return cdd
 
-    @pytest.mark.skip("not testing for now as this adds substantial wait time to test suite")
+    @pytest.mark.skip(
+        "not testing for now as this adds substantial wait time to test suite"
+    )
     def test_retrieve_molecule_data(self, cdddata):
         cdddata.retrieve_molecule_data()
 
@@ -42,7 +48,9 @@ class TestCDDData:
 
         assert all([mol["class"] == "molecule" for mol in molecules["objects"]])
 
-    @pytest.mark.skip("not testing for now as this adds substantial wait time to test suite")
+    @pytest.mark.skip(
+        "not testing for now as this adds substantial wait time to test suite"
+    )
     def test_retrieve_protocol_data(self, cdddata):
         protocol_ids = [cdddata.fluorescence_IC50_protocol_id]
         cdddata.retrieve_protocol_data(protocol_ids)
@@ -86,8 +94,8 @@ class TestCDDData:
 
     def test_retrieve_protocol_data_with_molecules(self, cdddata):
         # already performed in fixture
-        #protocol_ids = [cdddata.fluorescence_IC50_protocol_id]
-        #cdddata.retrieve_protocol_data(protocol_ids, molecules=True)
+        # protocol_ids = [cdddata.fluorescence_IC50_protocol_id]
+        # cdddata.retrieve_protocol_data(protocol_ids, molecules=True)
 
         assert (cdddata.data_dir / "molecules.json").exists()
 
@@ -137,16 +145,18 @@ class TestCDDData:
         protocol_ids = [cdddata.fluorescence_IC50_protocol_id]
 
         # already performed in fixture
-        #cdddata.retrieve_protocol_data(protocol_ids, molecules=True)
+        # cdddata.retrieve_protocol_data(protocol_ids, molecules=True)
 
         ec = cdddata.generate_experimental_compound_data(protocol_ids)
 
         # test that the fields indicating variety of compound are mutually exclusive in the data
         for compound in ec.compounds:
-            compound_varieties = [compound.racemic,
-                                  compound.achiral,
-                                  compound.absolute_stereochemistry_enantiomerically_pure,
-                                  compound.relative_stereochemistry_enantiomerically_pure]
+            compound_varieties = [
+                compound.racemic,
+                compound.achiral,
+                compound.absolute_stereochemistry_enantiomerically_pure,
+                compound.relative_stereochemistry_enantiomerically_pure,
+            ]
 
             if compound.smiles is not None:
                 assert sum(compound_varieties) == 1
@@ -154,7 +164,7 @@ class TestCDDData:
                 assert sum(compound_varieties) == 0
 
             # here we check that pIC50s are within a typical range
-            pIC50 = compound.experimental_data.get('pIC50')
+            pIC50 = compound.experimental_data.get("pIC50")
             if pIC50:
                 assert 3.0 < pIC50 < 8.0
 

--- a/fah_xchem/schema.py
+++ b/fah_xchem/schema.py
@@ -128,7 +128,10 @@ class ExperimentalCompoundData(Model):
         description="If True, this experiment was performed on a racemate; if False, the compound was enantiopure.",
     )
 
-    achiral: bool = Field(False, description="If True, this compound has no chiral centers or bonds, by definition enantiopure")
+    achiral: bool = Field(
+        False,
+        description="If True, this compound has no chiral centers or bonds, by definition enantiopure",
+    )
 
     absolute_stereochemistry_enantiomerically_pure: bool = Field(
         False,

--- a/fah_xchem/schema.py
+++ b/fah_xchem/schema.py
@@ -128,7 +128,7 @@ class ExperimentalCompoundData(Model):
     )
 
     experimental_data: Dict[str, float] = Field(
-        dict(),
+        ...,
         description='Experimental data fields, including "pIC50" and uncertainty (either "pIC50_stderr" or  "pIC50_{lower|upper}"',
     )
 

--- a/fah_xchem/schema.py
+++ b/fah_xchem/schema.py
@@ -113,6 +113,7 @@ class CompoundMetadata(Model):
 
 
 class ExperimentalCompoundData(Model):
+
     compound_id: str = Field(
         None, description="The unique compound identifier (PostEra or enumerated ID)"
     )
@@ -127,7 +128,7 @@ class ExperimentalCompoundData(Model):
         description="If True, this experiment was performed on a racemate; if False, the compound was enantiopure.",
     )
 
-    achiral: bool = Field(False, description="")
+    achiral: bool = Field(False, description="If True, this compound has no chiral centers or bonds, by definition enantiopure")
 
     absolute_stereochemistry_enantiomerically_pure: bool = Field(
         False,

--- a/fah_xchem/schema.py
+++ b/fah_xchem/schema.py
@@ -119,16 +119,31 @@ class ExperimentalCompoundData(Model):
 
     smiles: str = Field(
         None,
-        description="OpenEye canonical isomeric SMILES string defining suspected SMILES of racemic mixture (with unspecified stereochemistry) or specific enantiopure compound (if is_racemic=False); may differ from what is registered under compound_id.",
+        description="OpenEye canonical isomeric SMILES string defining suspected SMILES of racemic mixture (with unspecified stereochemistry) or specific enantiopure compound (if racemic=False); may differ from what is registered under compound_id.",
     )
 
-    is_racemic: bool = Field(
+    racemic: bool = Field(
         False,
         description="If True, this experiment was performed on a racemate; if False, the compound was enantiopure.",
     )
 
+    achiral: bool = Field(
+        False,
+        description=""
+    )
+
+    absolute_stereochemistry_enantiomerically_pure: bool = Field(
+        False,
+        description="If True, the compound was enantiopure and stereochemistry recorded in SMILES is correct"
+    )
+
+    relative_stereochemistry_enantiomerically_pure: bool = Field(
+        False,
+        description="If True, the compound was enantiopure, but unknown if stereochemistry recorded in SMILES is correct"
+    )
+
     experimental_data: Dict[str, float] = Field(
-        ...,
+        dict(),
         description='Experimental data fields, including "pIC50" and uncertainty (either "pIC50_stderr" or  "pIC50_{lower|upper}"',
     )
 

--- a/fah_xchem/schema.py
+++ b/fah_xchem/schema.py
@@ -127,19 +127,16 @@ class ExperimentalCompoundData(Model):
         description="If True, this experiment was performed on a racemate; if False, the compound was enantiopure.",
     )
 
-    achiral: bool = Field(
-        False,
-        description=""
-    )
+    achiral: bool = Field(False, description="")
 
     absolute_stereochemistry_enantiomerically_pure: bool = Field(
         False,
-        description="If True, the compound was enantiopure and stereochemistry recorded in SMILES is correct"
+        description="If True, the compound was enantiopure and stereochemistry recorded in SMILES is correct",
     )
 
     relative_stereochemistry_enantiomerically_pure: bool = Field(
         False,
-        description="If True, the compound was enantiopure, but unknown if stereochemistry recorded in SMILES is correct"
+        description="If True, the compound was enantiopure, but unknown if stereochemistry recorded in SMILES is correct",
     )
 
     experimental_data: Dict[str, float] = Field(

--- a/fah_xchem/testing.py
+++ b/fah_xchem/testing.py
@@ -1,0 +1,39 @@
+import pytest
+
+def pytest_addoption(parser):
+    """
+    Additional PyTest CLI flags to add
+
+    See `pytest_collection_modifyitems` for handling and `pytest_configure` for adding known in-line marks.
+    """
+    parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
+    parser.addoption("--runexamples", action="store_true", default=False, help="run example tests")
+
+
+def pytest_collection_modifyitems(config, items):
+    """
+    Handle test triggers based on the CLI flags
+
+    Use decorators:
+    @pytest.mark.slow
+    @pyrest.mark.example
+    """
+    runslow = config.getoption("--runslow")
+    runexamples = config.getoption("--runexamples")
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    skip_example = pytest.mark.skip(reason="need --runexamples option to run")
+    for item in items:
+        if "slow" in item.keywords and not runslow:
+            item.add_marker(skip_slow)
+        if "example" in item.keywords and not runexamples:
+            item.add_marker(skip_example)
+
+
+def pytest_configure(config):
+    import sys
+
+    sys._called_from_test = True
+    config.addinivalue_line("markers", "example: Mark a given test as an example which can be run")
+    config.addinivalue_line(
+        "markers", "slow: Mark a given test as slower than most other tests, needing a special " "flag to run."
+    )

--- a/fah_xchem/testing.py
+++ b/fah_xchem/testing.py
@@ -1,13 +1,18 @@
 import pytest
 
+
 def pytest_addoption(parser):
     """
     Additional PyTest CLI flags to add
 
     See `pytest_collection_modifyitems` for handling and `pytest_configure` for adding known in-line marks.
     """
-    parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
-    parser.addoption("--runexamples", action="store_true", default=False, help="run example tests")
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
+    parser.addoption(
+        "--runexamples", action="store_true", default=False, help="run example tests"
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -33,7 +38,11 @@ def pytest_configure(config):
     import sys
 
     sys._called_from_test = True
-    config.addinivalue_line("markers", "example: Mark a given test as an example which can be run")
     config.addinivalue_line(
-        "markers", "slow: Mark a given test as slower than most other tests, needing a special " "flag to run."
+        "markers", "example: Mark a given test as an example which can be run"
+    )
+    config.addinivalue_line(
+        "markers",
+        "slow: Mark a given test as slower than most other tests, needing a special "
+        "flag to run.",
     )

--- a/fah_xchem/tests/test_cli.py
+++ b/fah_xchem/tests/test_cli.py
@@ -17,7 +17,7 @@ runner = CliRunner()
 )
 class TestCDD:
 
-    protocol_ids = ("5549",)
+    protocol_ids = ("49439",)
 
     # @pytest.fixture(scope='class')
     # def cdddata_dir(self, tmpdir_factory):
@@ -36,6 +36,8 @@ class TestCDD:
                     "retrieve-molecule-data",
                 ],
             )
+
+            assert result.exit_code == 0
 
             # check for file presence
             assert os.path.exists("cdd-data/molecules.json")
@@ -60,6 +62,8 @@ class TestCDD:
                 ]
                 + protocols,
             )
+
+            assert result.exit_code == 0
 
             # check for file presence
             assert not os.path.exists("cdd-data/molecules.json")
@@ -89,6 +93,8 @@ class TestCDD:
                 ]
                 + protocols,
             )
+
+            assert result.exit_code == 0
 
             # check for file presence
             assert os.path.exists("cdd-data/molecules.json")

--- a/fah_xchem/tests/test_cli.py
+++ b/fah_xchem/tests/test_cli.py
@@ -1,0 +1,117 @@
+import os
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from fah_xchem.cli import cli
+from fah_xchem.schema import ExperimentalCompoundDataUpdate
+
+runner = CliRunner()
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    (("CDD_VAULT_TOKEN" not in os.environ) and ("CDD_VAULT_NUM" not in os.environ)),
+    reason="require both CDD_VAULT_TOKEN and CDD_VAULT_NUM to run CDD tests",
+)
+class TestCDD:
+
+    protocol_ids = ('5549',)
+
+    #@pytest.fixture(scope='class')
+    #def cdddata_dir(self, tmpdir_factory):
+    #    return tmpdir_factory.mktemp('cdd-data')
+
+    def test_retrieve_molecule_data(self, tmpdir):
+        with tmpdir.as_cwd():
+
+            # download molecule and protocol data
+            result = runner.invoke(cli, ['cdd',
+                                         '--data-dir', 
+                                         'cdd-data',
+                                         'retrieve-molecule-data',
+                                         ])
+            
+            # check for file presence
+            assert os.path.exists('cdd-data/molecules.json')
+
+    def test_retrieve_protocol_data(self, tmpdir):
+        with tmpdir.as_cwd():
+
+            # build up args for protocol ids
+            protocols = []
+            for pid in self.protocol_ids:
+                protocols.append('-i')
+                protocols.append(pid)
+
+            # download molecule and protocol data
+            result = runner.invoke(cli, ['cdd',
+                                         '--data-dir', 
+                                         'cdd-data',
+                                         'retrieve-protocol-data',
+                                         ] + protocols)
+
+            # check for file presence
+            assert not os.path.exists('cdd-data/molecules.json')
+            for pid in self.protocol_ids:
+                assert os.path.exists(f'cdd-data/protocols/{pid}')
+                assert os.path.exists(f'cdd-data/protocols/{pid}/protocol-defs.json')
+                assert os.path.exists(f'cdd-data/protocols/{pid}/protocol-records.json')
+
+    def test_retrieve_protocol_data_with_molecules(self, tmpdir):
+        with tmpdir.as_cwd():
+
+            # build up args for protocol ids
+            protocols = []
+            for pid in self.protocol_ids:
+                protocols.append('-i')
+                protocols.append(pid)
+
+            # download molecule and protocol data
+            result = runner.invoke(cli, ['cdd',
+                                         '--data-dir', 
+                                         'cdd-data',
+                                         'retrieve-protocol-data',
+                                         '--molecules',
+                                         ] + protocols)
+
+            # check for file presence
+            assert os.path.exists('cdd-data/molecules.json')
+            for pid in self.protocol_ids:
+                assert os.path.exists(f'cdd-data/protocols/{pid}')
+                assert os.path.exists(f'cdd-data/protocols/{pid}/protocol-defs.json')
+                assert os.path.exists(f'cdd-data/protocols/{pid}/protocol-records.json')
+
+    def test_generate_experimental_compound_data(self, tmpdir):
+
+        with tmpdir.as_cwd():
+
+            # build up args for protocol ids
+            protocols = []
+            for pid in self.protocol_ids:
+                protocols.append('-i')
+                protocols.append(pid)
+
+            # download molecule and protocol data
+            result = runner.invoke(cli, ['cdd',
+                                         '--data-dir', 
+                                         'cdd-data',
+                                         'retrieve-protocol-data',
+                                         '--molecules',
+                                         ] + protocols)
+
+
+            assert result.exit_code == 0
+
+            # generate downstream experimental data and analyze
+            result = runner.invoke(cli, ['cdd',
+                                         '--data-dir', 
+                                         'cdd-data',
+                                         'generate-experimental-compound-data',
+                                         ] + protocols + ['experimental-data.json'])
+
+            assert result.exit_code == 0
+
+            # load experimental compound data and use schema; will fail if not possible
+            with open('experimental-data.json', 'r') as f:
+                exp_data = ExperimentalCompoundDataUpdate.parse_raw(f.read())

--- a/fah_xchem/tests/test_cli.py
+++ b/fah_xchem/tests/test_cli.py
@@ -9,6 +9,7 @@ from fah_xchem.schema import ExperimentalCompoundDataUpdate
 
 runner = CliRunner()
 
+
 @pytest.mark.slow
 @pytest.mark.skipif(
     (("CDD_VAULT_TOKEN" not in os.environ) and ("CDD_VAULT_NUM" not in os.environ)),
@@ -16,24 +17,28 @@ runner = CliRunner()
 )
 class TestCDD:
 
-    protocol_ids = ('5549',)
+    protocol_ids = ("5549",)
 
-    #@pytest.fixture(scope='class')
-    #def cdddata_dir(self, tmpdir_factory):
+    # @pytest.fixture(scope='class')
+    # def cdddata_dir(self, tmpdir_factory):
     #    return tmpdir_factory.mktemp('cdd-data')
 
     def test_retrieve_molecule_data(self, tmpdir):
         with tmpdir.as_cwd():
 
             # download molecule and protocol data
-            result = runner.invoke(cli, ['cdd',
-                                         '--data-dir', 
-                                         'cdd-data',
-                                         'retrieve-molecule-data',
-                                         ])
-            
+            result = runner.invoke(
+                cli,
+                [
+                    "cdd",
+                    "--data-dir",
+                    "cdd-data",
+                    "retrieve-molecule-data",
+                ],
+            )
+
             # check for file presence
-            assert os.path.exists('cdd-data/molecules.json')
+            assert os.path.exists("cdd-data/molecules.json")
 
     def test_retrieve_protocol_data(self, tmpdir):
         with tmpdir.as_cwd():
@@ -41,22 +46,27 @@ class TestCDD:
             # build up args for protocol ids
             protocols = []
             for pid in self.protocol_ids:
-                protocols.append('-i')
+                protocols.append("-i")
                 protocols.append(pid)
 
             # download molecule and protocol data
-            result = runner.invoke(cli, ['cdd',
-                                         '--data-dir', 
-                                         'cdd-data',
-                                         'retrieve-protocol-data',
-                                         ] + protocols)
+            result = runner.invoke(
+                cli,
+                [
+                    "cdd",
+                    "--data-dir",
+                    "cdd-data",
+                    "retrieve-protocol-data",
+                ]
+                + protocols,
+            )
 
             # check for file presence
-            assert not os.path.exists('cdd-data/molecules.json')
+            assert not os.path.exists("cdd-data/molecules.json")
             for pid in self.protocol_ids:
-                assert os.path.exists(f'cdd-data/protocols/{pid}')
-                assert os.path.exists(f'cdd-data/protocols/{pid}/protocol-defs.json')
-                assert os.path.exists(f'cdd-data/protocols/{pid}/protocol-records.json')
+                assert os.path.exists(f"cdd-data/protocols/{pid}")
+                assert os.path.exists(f"cdd-data/protocols/{pid}/protocol-defs.json")
+                assert os.path.exists(f"cdd-data/protocols/{pid}/protocol-records.json")
 
     def test_retrieve_protocol_data_with_molecules(self, tmpdir):
         with tmpdir.as_cwd():
@@ -64,23 +74,28 @@ class TestCDD:
             # build up args for protocol ids
             protocols = []
             for pid in self.protocol_ids:
-                protocols.append('-i')
+                protocols.append("-i")
                 protocols.append(pid)
 
             # download molecule and protocol data
-            result = runner.invoke(cli, ['cdd',
-                                         '--data-dir', 
-                                         'cdd-data',
-                                         'retrieve-protocol-data',
-                                         '--molecules',
-                                         ] + protocols)
+            result = runner.invoke(
+                cli,
+                [
+                    "cdd",
+                    "--data-dir",
+                    "cdd-data",
+                    "retrieve-protocol-data",
+                    "--molecules",
+                ]
+                + protocols,
+            )
 
             # check for file presence
-            assert os.path.exists('cdd-data/molecules.json')
+            assert os.path.exists("cdd-data/molecules.json")
             for pid in self.protocol_ids:
-                assert os.path.exists(f'cdd-data/protocols/{pid}')
-                assert os.path.exists(f'cdd-data/protocols/{pid}/protocol-defs.json')
-                assert os.path.exists(f'cdd-data/protocols/{pid}/protocol-records.json')
+                assert os.path.exists(f"cdd-data/protocols/{pid}")
+                assert os.path.exists(f"cdd-data/protocols/{pid}/protocol-defs.json")
+                assert os.path.exists(f"cdd-data/protocols/{pid}/protocol-records.json")
 
     def test_generate_experimental_compound_data(self, tmpdir):
 
@@ -89,29 +104,39 @@ class TestCDD:
             # build up args for protocol ids
             protocols = []
             for pid in self.protocol_ids:
-                protocols.append('-i')
+                protocols.append("-i")
                 protocols.append(pid)
 
             # download molecule and protocol data
-            result = runner.invoke(cli, ['cdd',
-                                         '--data-dir', 
-                                         'cdd-data',
-                                         'retrieve-protocol-data',
-                                         '--molecules',
-                                         ] + protocols)
-
+            result = runner.invoke(
+                cli,
+                [
+                    "cdd",
+                    "--data-dir",
+                    "cdd-data",
+                    "retrieve-protocol-data",
+                    "--molecules",
+                ]
+                + protocols,
+            )
 
             assert result.exit_code == 0
 
             # generate downstream experimental data and analyze
-            result = runner.invoke(cli, ['cdd',
-                                         '--data-dir', 
-                                         'cdd-data',
-                                         'generate-experimental-compound-data',
-                                         ] + protocols + ['experimental-data.json'])
+            result = runner.invoke(
+                cli,
+                [
+                    "cdd",
+                    "--data-dir",
+                    "cdd-data",
+                    "generate-experimental-compound-data",
+                ]
+                + protocols
+                + ["experimental-data.json"],
+            )
 
             assert result.exit_code == 0
 
             # load experimental compound data and use schema; will fail if not possible
-            with open('experimental-data.json', 'r') as f:
+            with open("experimental-data.json", "r") as f:
                 exp_data = ExperimentalCompoundDataUpdate.parse_raw(f.read())

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,3 +28,7 @@ tag_prefix = ''
 
 [aliases]
 test = pytest
+
+[tool:pytest]
+markers = 
+    slow: Run slow tests.

--- a/setup.py
+++ b/setup.py
@@ -65,5 +65,8 @@ setup(
     # python_requires=">=3.5",          # Python version restrictions
     # Manual control if final package is compressible or not, set False to prevent the .egg from being made
     # zip_safe=False,
-    entry_points={"console_scripts": ["fah-xchem = fah_xchem.cli:cli"]},
+    entry_points={
+        "console_scripts": ["fah-xchem = fah_xchem.cli:cli"],
+        "pytest11": ["fah_xchem_testing = fah_xchem.testing"],
+    },
 )


### PR DESCRIPTION
This PR completes the `CDDData.generate_experimental_compound_data` method, yielding an `ExperimentalCompoundDataUpdate` object that can be consumed by e.g. `fah-xchem compound-series analyze`.

This method will be callable via the CLI using `fah-xchem cdd generate-experimental-compound-data`.

## Status
- [x] Ready to go